### PR TITLE
Unit Test: Twint on MultiProcess

### DIFF
--- a/src/storage/processors/twint_with_multiprocess.py
+++ b/src/storage/processors/twint_with_multiprocess.py
@@ -24,8 +24,8 @@ logger = logging.getLogger(__name__)
 
 def run_twint_with_multiprocessing(
         twint_configs,
-        twitter_analyzer_storage_addr,
-        twitter_analyzer_storage_port,
+        rpc_storage_addr,
+        rpc_storage_port,
         nb_tweets_by_chunk=20,
         log_level: Optional[str] = None
 ):
@@ -33,8 +33,8 @@ def run_twint_with_multiprocessing(
 
     Args:
         twint_configs:
-        twitter_analyzer_storage_addr:
-        twitter_analyzer_storage_port:
+        rpc_storage_addr:
+        rpc_storage_port:
         nb_tweets_by_chunk:
         log_level:
 
@@ -52,8 +52,8 @@ def run_twint_with_multiprocessing(
         kwargs={
             'queue_sync_with_twint': mp_queue,
             'event_twint_worker_is_finish': mp_event_twint_worker_is_finish,
-            'twitter_analyzer_storage_addr': twitter_analyzer_storage_addr,
-            'twitter_analyzer_storage_port': twitter_analyzer_storage_port,
+            'twitter_analyzer_storage_addr': rpc_storage_addr,
+            'twitter_analyzer_storage_port': rpc_storage_port,
             'nb_tweets_by_chunk': nb_tweets_by_chunk,
             'log_level': log_level,
         }

--- a/src/storage/processors/twint_with_multiprocess.py
+++ b/src/storage/processors/twint_with_multiprocess.py
@@ -123,11 +123,14 @@ def loop_consume_tweets_from_twint_mp(
         init_logger(log_level)
 
     # init gRPC stub to access to Storage service(r)
-    storage_rpc_stub = rpc_init_stub(
-        twitter_analyzer_storage_addr, twitter_analyzer_storage_port,
-        StorageService_pb2_grpc.StorageServiceStub,
-        service_name='[twint-multiprocessing] twitter analyzer storage'
-    )
+    storage_rpc_stub = None
+    if twitter_analyzer_storage_addr and twitter_analyzer_storage_port:
+        storage_rpc_stub = rpc_init_stub(
+            twitter_analyzer_storage_addr,
+            twitter_analyzer_storage_port,
+            StorageService_pb2_grpc.StorageServiceStub,
+            service_name='[twint-multiprocessing] twitter analyzer storage'
+        )
 
     def _func_exit_loop():
         #
@@ -225,16 +228,17 @@ def loop_store_tweets(
             StorageService_pb2.StoreTweetsRequest(tweet=tweet)
             for tweet in chunk_tweets
         ]
-        if storage_rpc_stub:
-            debug_infos = ", ".join(
+
+        def _format_debug_infos():
+            return ", ".join(
                 f"{user_name}#{counter}"
-                for user_name, counter in Counter(
-                    [tweet.tweet.user_name.lower()
-                     for tweet in tweets]).items()
+                for user_name, counter in Counter([tweet.tweet.user_name.lower() for tweet in tweets]).items()
             )
-            logger.debug(
-                f"gRPC: store {len(tweets)} tweets "
-                f"from users=({debug_infos}) in db ...")
+
+        logger.debug("gRPC: store %d tweets from users=(%s) in db ...", len(tweets), _format_debug_infos())
+
+        if storage_rpc_stub:
+            # -> gRPC Storage service
             store_tweets_stream_response = MessageToDict(
                 storage_rpc_stub.StoreTweetsStream(iter(tweets)),
                 including_default_value_fields=True

--- a/tests/test_run_twint_with_multiprocessing.py
+++ b/tests/test_run_twint_with_multiprocessing.py
@@ -1,0 +1,29 @@
+import logging
+import math
+
+import twint
+
+from storage.processors.twint_with_multiprocess import run_twint_with_multiprocessing
+
+
+def test_run_twint_with_multiprocessing(caplog):
+    twint_configs = []
+    twitter_users = ["PyConFr"]
+    twint_limit = 25
+    nb_tweets_by_chunk = 20
+    twint_debug = False
+    for twitter_user in twitter_users:
+        twint_config = twint.Config()
+        twint_config.Username = twitter_user
+        twint_config.Limit = twint_limit  # bug with the Limit parameter not working only factor of 25 tweets
+        twint_config.Debug = twint_debug
+        twint_configs.append(twint_config)
+    twitter_analyzer_storage_host = (None, None)
+    with caplog.at_level(logging.DEBUG):
+        run_twint_with_multiprocessing(
+            twint_configs,
+            *twitter_analyzer_storage_host,
+            nb_tweets_by_chunk=nb_tweets_by_chunk,
+            log_level="debug"
+        )
+    assert len(caplog.records) == math.ceil(twint_limit / float(nb_tweets_by_chunk))

--- a/tests/test_run_twint_with_multiprocessing.py
+++ b/tests/test_run_twint_with_multiprocessing.py
@@ -1,12 +1,17 @@
 import logging
-import math
+import multiprocessing
+import queue
+from dataclasses import dataclass
+from typing import Iterator
 
+import math
 import twint
+from pyconfr_2019.grpc_nlp.protos.StorageService_pb2 import StoreTweetsResponse
 
 from storage.processors.twint_with_multiprocess import run_twint_with_multiprocessing
 
 
-def test_run_twint_with_multiprocessing(caplog):
+def test_run_twint_with_multiprocessing(mocker, caplog):
     twint_configs = []
     twitter_users = ["PyConFr"]
     twint_limit = 25
@@ -18,12 +23,53 @@ def test_run_twint_with_multiprocessing(caplog):
         twint_config.Limit = twint_limit  # bug with the Limit parameter not working only factor of 25 tweets
         twint_config.Debug = twint_debug
         twint_configs.append(twint_config)
-    twitter_analyzer_storage_host = (None, None)
+
+    class MockRpcInitStub:
+        def __init__(self, _mp_queue: queue.Queue):
+            self._mp_queue = _mp_queue
+
+        def StoreTweetsStream(self, iter_pb2_tweets_responses: Iterator[StoreTweetsResponse]):
+            pb2_tweets = list(iter_pb2_tweets_responses)
+            for pb2_tweet in pb2_tweets:
+                self._mp_queue.put(pb2_tweet)
+            return StoreTweetsResponse(nb_tweets_received=len(pb2_tweets),
+                                       nb_tweets_stored=len(pb2_tweets))
+
+    mock_rpc_init_stub = mocker.patch('storage.processors.twint_with_multiprocess.rpc_init_stub')
+    # Need to use a MultiProcess (synchronized) Queue
+    mp_manager = multiprocessing.Manager()
+    mp_queue = mp_manager.Queue()
+    mock_rpc_init_stub.return_value = MockRpcInitStub(mp_queue)
+
+    # https://docs.pytest.org/en/latest/logging.html
     with caplog.at_level(logging.DEBUG):
         run_twint_with_multiprocessing(
             twint_configs,
-            *twitter_analyzer_storage_host,
+            *('Test', 12345),  # dummy connection parameters to instantiate
+            # a connection to rpc storage server
             nb_tweets_by_chunk=nb_tweets_by_chunk,
             log_level="debug"
         )
-    assert len(caplog.records) == math.ceil(twint_limit / float(nb_tweets_by_chunk))
+
+    nb_twitter_api_requests = math.ceil(twint_limit / float(nb_tweets_by_chunk))
+    assert len(caplog.records) == nb_twitter_api_requests
+
+    # Generator on tweets saved in MP Queue
+    @dataclass
+    class GenPb2Tweets:
+        queue: queue.Queue
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            while True:
+                try:
+                    pb2_tweets = self.queue.get_nowait()
+                    break
+                except queue.Empty:
+                    raise StopIteration
+            return pb2_tweets
+
+    tweets = list(GenPb2Tweets(mp_queue))
+    assert len(tweets) == nb_tweets_by_chunk * nb_twitter_api_requests


### PR DESCRIPTION
# Actions

Write unit test (close to functional test ... :/) for `run_twint_with_multiprocessing` using mock on `rpc_init_stub` and multiprocess queue to mock and store tweets retrieve from twitter (via `twint`).